### PR TITLE
fix: consertar atualização de MovieVotes ao cadastrar Review

### DIFF
--- a/src/main/java/br/com/emendes/yourreviewapi/service/impl/ReviewServiceImpl.java
+++ b/src/main/java/br/com/emendes/yourreviewapi/service/impl/ReviewServiceImpl.java
@@ -59,6 +59,9 @@ public class ReviewServiceImpl implements ReviewService {
     review.setMovieVotes(movieVotes);
     review.setCreatedAt(LocalDateTime.now());
 
+    movieVotes.setVoteTotal(movieVotes.getVoteTotal() + review.getVote());
+    movieVotes.setVoteCount(movieVotes.getVoteCount() + 1);
+
     review = reviewRepository.save(review);
 
     log.info("Review registered successfully with id: {}", review.getId());


### PR DESCRIPTION
Ao cadastrar uma Review, as colunas *voteTotal* e *voteCount* da tabela *tb_movie_votes* não eram atualizadas com o valor do voto da Review cadastrada.