### PR TITLE
perf: fazer a busca ReviewRepository#findByIdAndUserId buscar MovieVotes associado

### DIFF
--- a/src/main/java/br/com/emendes/yourreviewapi/model/entity/Review.java
+++ b/src/main/java/br/com/emendes/yourreviewapi/model/entity/Review.java
@@ -25,7 +25,7 @@ public class Review {
   private int vote;
   @Column(name = "opinion")
   private String opinion;
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   private User user;
   @ManyToOne(cascade = {CascadeType.PERSIST})
   private MovieVotes movieVotes;

--- a/src/main/java/br/com/emendes/yourreviewapi/repository/ReviewRepository.java
+++ b/src/main/java/br/com/emendes/yourreviewapi/repository/ReviewRepository.java
@@ -53,12 +53,21 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
   Optional<ReviewDetailsProjection> findProjectedById(Long reviewId);
 
   /**
-   * Busca {@link Review} por reviewId e user.
+   * Busca {@link Review} por {@code reviewId} e {@code userId},
+   * traz junto o MovieVotes associado com a Review encontrada.<br>
+   * <b>NÃO TRAZ</b> o User do relacionamento Review-User.
    *
    * @param reviewId identificador da Review.
-   * @param user     user relacionado com a review de id reviewId.
+   * @param userId     user relacionado com a review de id reviewId.
    * @return {@code Optional<Review>}
    */
-  Optional<Review> findByIdAndUser(Long reviewId, User user);
+  @Query("""
+      SELECT r
+        FROM Review r
+        JOIN FETCH r.movieVotes
+        WHERE r.id = :reviewId
+        AND r.user.id = :userId
+      """)
+  Optional<Review> findByIdAndUserId(@Param("reviewId") Long reviewId, @Param("userId") Long userId);
 
 }

--- a/src/main/java/br/com/emendes/yourreviewapi/service/impl/ReviewServiceImpl.java
+++ b/src/main/java/br/com/emendes/yourreviewapi/service/impl/ReviewServiceImpl.java
@@ -92,7 +92,7 @@ public class ReviewServiceImpl implements ReviewService {
     log.info("Attempt to update review with id: {}", reviewId);
     User currentUser = authenticatedUserComponent.getCurrentUser();
 
-    Review review = reviewRepository.findByIdAndUser(reviewId, currentUser)
+    Review review = reviewRepository.findByIdAndUserId(reviewId, currentUser.getId())
         .orElseThrow(() -> getReviewNotFoundException(reviewId));
 
     updateVoteTotal(review.getMovieVotes(), review.getVote(), reviewUpdateRequest.vote());
@@ -111,7 +111,7 @@ public class ReviewServiceImpl implements ReviewService {
     log.info("Attempt to delete review with id: {}", reviewId);
     User currentUser = authenticatedUserComponent.getCurrentUser();
 
-    Optional<Review> reviewOptional = reviewRepository.findByIdAndUser(reviewId, currentUser);
+    Optional<Review> reviewOptional = reviewRepository.findByIdAndUserId(reviewId, currentUser.getId());
     if (reviewOptional.isEmpty()) {
       throw getReviewNotFoundException(reviewId);
     }

--- a/src/test/java/br/com/emendes/yourreviewapi/integration/repository/ReviewRepositoryTest.java
+++ b/src/test/java/br/com/emendes/yourreviewapi/integration/repository/ReviewRepositoryTest.java
@@ -1,7 +1,6 @@
 package br.com.emendes.yourreviewapi.integration.repository;
 
 import br.com.emendes.yourreviewapi.model.entity.Review;
-import br.com.emendes.yourreviewapi.model.entity.User;
 import br.com.emendes.yourreviewapi.repository.ReviewRepository;
 import br.com.emendes.yourreviewapi.repository.projection.ReviewDetailsProjection;
 import br.com.emendes.yourreviewapi.repository.projection.ReviewSummaryProjection;
@@ -157,19 +156,17 @@ class ReviewRepositoryTest {
   }
 
   @Nested
-  @DisplayName("FindByIdAndUser Method")
-  class findByIdAndUserMethod {
+  @DisplayName("FindByIdAndUserId Method")
+  class findByIdAndUserIdMethod {
 
     @SqlMergeMode(SqlMergeMode.MergeMode.MERGE)
     @Sql(scripts = {INSERT_REVIEW_SQL_PATH})
     @Test
-    @DisplayName("findByIdAndUser must return Optional<Review> when found Review for given reviewId and user")
-    void findByIdAndUser_MustReturnOptionalReview_WhenFoundReviewForGivenReviewIdAndUser() {
-      User user = User.builder()
-          .id(1L)
-          .build();
+    @DisplayName("findByIdAndUserId must return Optional<Review> when found Review for given reviewId and user")
+    void findByIdAndUserId_MustReturnOptionalReview_WhenFoundReviewForGivenReviewIdAndUser() {
+      Long userId = 1L;
 
-      Optional<Review> actualReviewOptional = reviewRepository.findByIdAndUser(1L, user);
+      Optional<Review> actualReviewOptional = reviewRepository.findByIdAndUserId(1L, userId);
 
       assertThat(actualReviewOptional).isNotEmpty();
 
@@ -187,13 +184,11 @@ class ReviewRepositoryTest {
     @SqlMergeMode(SqlMergeMode.MergeMode.MERGE)
     @Sql(scripts = {INSERT_REVIEW_SQL_PATH})
     @Test
-    @DisplayName("findByIdAndUser must return empty Optional when not found Review for given reviewId and user")
-    void findByIdAndUser_MustReturnEmptyOptional_WhenNotFoundReviewForGivenReviewId() {
-      User user = User.builder()
-          .id(1L)
-          .build();
+    @DisplayName("findByIdAndUserId must return empty Optional when not found Review for given reviewId and user")
+    void findByIdAndUserId_MustReturnEmptyOptional_WhenNotFoundReviewForGivenReviewId() {
+      Long userId = 1L;
 
-      Optional<Review> actualReviewOptional = reviewRepository.findByIdAndUser(2L, user);
+      Optional<Review> actualReviewOptional = reviewRepository.findByIdAndUserId(2L, userId);
 
       assertThat(actualReviewOptional).isEmpty();
     }


### PR DESCRIPTION
A busca do método ReviewRepository#findByIdAndUser realizava três *selects*, um para trazer a entidade *Review*, outro para *MovieVotes* e outro o *User* com suas *Authorities.* Então fiz com que a busca retorne a entidade Review e MovieVotes associado com um único *select*, e a entidade User como Lazy Loading.

tornar o relacionamento Review-User lazy loaded

fazer a busca ReviewRepository#findByIdAndUserId trazer a entidade MovieVotes associada

atualizar ReviewRepository integration tests de acordo com as mudanças acimas