### PR TITLE
feat: buscar movie info quando buscar review por id

### DIFF
--- a/src/main/java/br/com/emendes/yourreviewapi/controller/MovieController.java
+++ b/src/main/java/br/com/emendes/yourreviewapi/controller/MovieController.java
@@ -39,7 +39,7 @@ public class MovieController {
   @GetMapping("/{id}")
   public ResponseEntity<MovieDetailsResponse> findById(
       @PathVariable("id") String movieId) {
-    return ResponseEntity.ok(movieService.findById(movieId));
+    return ResponseEntity.ok(movieService.findDetailedById(movieId));
   }
 
 }

--- a/src/main/java/br/com/emendes/yourreviewapi/controller/ReviewController.java
+++ b/src/main/java/br/com/emendes/yourreviewapi/controller/ReviewController.java
@@ -3,6 +3,7 @@ package br.com.emendes.yourreviewapi.controller;
 import br.com.emendes.yourreviewapi.dto.request.ReviewRegisterRequest;
 import br.com.emendes.yourreviewapi.dto.request.ReviewUpdateRequest;
 import br.com.emendes.yourreviewapi.dto.response.ReviewDetailsResponse;
+import br.com.emendes.yourreviewapi.dto.response.ReviewResponse;
 import br.com.emendes.yourreviewapi.dto.response.ReviewSummaryResponse;
 import br.com.emendes.yourreviewapi.service.ReviewService;
 import lombok.RequiredArgsConstructor;
@@ -31,13 +32,13 @@ public class ReviewController {
    *                              location do recurso criado.
    */
   @PostMapping
-  public ResponseEntity<ReviewDetailsResponse> register(
+  public ResponseEntity<ReviewResponse> register(
       @RequestBody ReviewRegisterRequest reviewRegisterRequest,
       UriComponentsBuilder uriBuilder) {
-    ReviewDetailsResponse reviewDetailsResponse = reviewService.register(reviewRegisterRequest);
-    URI uri = uriBuilder.path("/api/v1/reviews/{id}").build(reviewDetailsResponse.id());
+    ReviewResponse reviewResponse = reviewService.register(reviewRegisterRequest);
+    URI uri = uriBuilder.path("/api/v1/reviews/{id}").build(reviewResponse.id());
 
-    return ResponseEntity.created(uri).body(reviewDetailsResponse);
+    return ResponseEntity.created(uri).body(reviewResponse);
   }
 
   /**
@@ -70,7 +71,7 @@ public class ReviewController {
    * @param reviewUpdateRequest objeto com os novos dados da Review.
    */
   @PutMapping("/{reviewId}")
-  public ResponseEntity<ReviewDetailsResponse> updateById(
+  public ResponseEntity<ReviewResponse> updateById(
       @PathVariable("reviewId") Long reviewId,
       @RequestBody ReviewUpdateRequest reviewUpdateRequest) {
     return ResponseEntity.ok(reviewService.updateById(reviewId, reviewUpdateRequest));

--- a/src/main/java/br/com/emendes/yourreviewapi/dto/response/ReviewResponse.java
+++ b/src/main/java/br/com/emendes/yourreviewapi/dto/response/ReviewResponse.java
@@ -11,16 +11,16 @@ import java.time.LocalDateTime;
  * @param vote      valor do voto do filme avaliado.
  * @param opinion   opinião do usuário sobre o filme.
  * @param userId    identificador do usuário que fez esta Review.
- * @param movie     informações resumidas do Movie relacionado a review.
+ * @param movieId   idenficador do filme o qual a review se aplica.
  * @param createdAt data de criação da review.
  */
 @Builder
-public record ReviewDetailsResponse(
+public record ReviewResponse(
     Long id,
     int vote,
     String opinion,
     Long userId,
-    MovieSummaryResponse movie,
+    String movieId,
     LocalDateTime createdAt
 ) {
 }

--- a/src/main/java/br/com/emendes/yourreviewapi/dto/response/ReviewSummaryResponse.java
+++ b/src/main/java/br/com/emendes/yourreviewapi/dto/response/ReviewSummaryResponse.java
@@ -8,7 +8,7 @@ import lombok.Builder;
  * @param id      identificador da Review
  * @param vote    valor do voto do filme avaliado.
  * @param opinion opinião do usuário sobre o filme.
- * @param userId  identificador do usuário que fez está Review.
+ * @param user    informações do user relacionado a esta review.
  * @param movieId idenficador do filme o qual a review se aplica.
  */
 @Builder

--- a/src/main/java/br/com/emendes/yourreviewapi/mapper/ReviewMapper.java
+++ b/src/main/java/br/com/emendes/yourreviewapi/mapper/ReviewMapper.java
@@ -2,8 +2,11 @@ package br.com.emendes.yourreviewapi.mapper;
 
 import br.com.emendes.yourreviewapi.dto.request.ReviewRegisterRequest;
 import br.com.emendes.yourreviewapi.dto.request.ReviewUpdateRequest;
+import br.com.emendes.yourreviewapi.dto.response.MovieSummaryResponse;
 import br.com.emendes.yourreviewapi.dto.response.ReviewDetailsResponse;
+import br.com.emendes.yourreviewapi.dto.response.ReviewResponse;
 import br.com.emendes.yourreviewapi.dto.response.ReviewSummaryResponse;
+import br.com.emendes.yourreviewapi.model.Movie;
 import br.com.emendes.yourreviewapi.model.entity.Review;
 import br.com.emendes.yourreviewapi.repository.projection.ReviewDetailsProjection;
 import br.com.emendes.yourreviewapi.repository.projection.ReviewSummaryProjection;
@@ -23,22 +26,23 @@ public interface ReviewMapper {
   Review toReview(ReviewRegisterRequest reviewRegisterRequest);
 
   /**
-   * Mapeia um objeto {@link Review} para {@link ReviewDetailsResponse}.
+   * Mapeia um objeto {@link Review} para {@link ReviewResponse}.
    *
-   * @param review objeto a ser mapeado para ReviewDetailsResponse.
-   * @return Objeto ReviewDetailsResponse com os dados de Review.
+   * @param review objeto a ser mapeado para ReviewResponse.
+   * @return Objeto ReviewResponse com os dados de Review.
    * @throws IllegalArgumentException caso review seja null.
    */
-  ReviewDetailsResponse toReviewDetailsResponse(Review review);
+  ReviewResponse toReviewResponse(Review review);
 
   /**
    * Mapeia um objeto {@link ReviewDetailsProjection} para {@link ReviewDetailsResponse}.
    *
    * @param reviewDetailsProjection objeto a ser mapeado para ReviewDetailsResponse.
+   * @param movie                   objeto a ser mapeado e adicionado a ReviewDetailsResponse.
    * @return Objeto ReviewDetailsResponse com os dados de ReviewDetailsProjection.
    * @throws IllegalArgumentException caso reviewDetailsProjection seja null.
    */
-  ReviewDetailsResponse toReviewDetailsResponse(ReviewDetailsProjection reviewDetailsProjection);
+  ReviewDetailsResponse toReviewDetailsResponse(ReviewDetailsProjection reviewDetailsProjection, MovieSummaryResponse movie);
 
   /**
    * Mapeia um objeto {@link Review} para {@link ReviewSummaryResponse}.

--- a/src/main/java/br/com/emendes/yourreviewapi/mapper/impl/ReviewMapperImpl.java
+++ b/src/main/java/br/com/emendes/yourreviewapi/mapper/impl/ReviewMapperImpl.java
@@ -2,9 +2,7 @@ package br.com.emendes.yourreviewapi.mapper.impl;
 
 import br.com.emendes.yourreviewapi.dto.request.ReviewRegisterRequest;
 import br.com.emendes.yourreviewapi.dto.request.ReviewUpdateRequest;
-import br.com.emendes.yourreviewapi.dto.response.ReviewDetailsResponse;
-import br.com.emendes.yourreviewapi.dto.response.ReviewSummaryResponse;
-import br.com.emendes.yourreviewapi.dto.response.UserSummaryResponse;
+import br.com.emendes.yourreviewapi.dto.response.*;
 import br.com.emendes.yourreviewapi.mapper.ReviewMapper;
 import br.com.emendes.yourreviewapi.model.entity.Review;
 import br.com.emendes.yourreviewapi.repository.projection.ReviewDetailsProjection;
@@ -29,10 +27,10 @@ public class ReviewMapperImpl implements ReviewMapper {
   }
 
   @Override
-  public ReviewDetailsResponse toReviewDetailsResponse(Review review) {
+  public ReviewResponse toReviewResponse(Review review) {
     Assert.notNull(review, "review must not be null");
 
-    return ReviewDetailsResponse.builder()
+    return ReviewResponse.builder()
         .id(review.getId())
         .movieId(review.getMovieVotes().getMovieId())
         .vote(review.getVote())
@@ -43,12 +41,15 @@ public class ReviewMapperImpl implements ReviewMapper {
   }
 
   @Override
-  public ReviewDetailsResponse toReviewDetailsResponse(ReviewDetailsProjection reviewDetailsProjection) {
+  public ReviewDetailsResponse toReviewDetailsResponse(
+      ReviewDetailsProjection reviewDetailsProjection,
+      MovieSummaryResponse movie) {
     Assert.notNull(reviewDetailsProjection, "reviewDetailsProjection must not be null");
+    Assert.notNull(movie, "movie must not be null");
 
     return ReviewDetailsResponse.builder()
         .id(reviewDetailsProjection.getId())
-        .movieId(reviewDetailsProjection.getMovieVotesMovieId())
+        .movie(movie)
         .vote(reviewDetailsProjection.getVote())
         .opinion(reviewDetailsProjection.getOpinion())
         .userId(reviewDetailsProjection.getUserId())
@@ -74,7 +75,6 @@ public class ReviewMapperImpl implements ReviewMapper {
         .user(userSummaryResponse)
         .build();
   }
-
 
   @Override
   public void merge(Review review, ReviewUpdateRequest reviewUpdateRequest) {

--- a/src/main/java/br/com/emendes/yourreviewapi/service/MovieService.java
+++ b/src/main/java/br/com/emendes/yourreviewapi/service/MovieService.java
@@ -26,12 +26,21 @@ public interface MovieService {
       @PositiveOrZero(message = "{MovieService.findByName.page.PositiveOrZero.message}") int page);
 
   /**
-   * Busca filme por id.
+   * Busca informações detalhadas do Movie por id.
    *
    * @param movieId identificador do filme a ser buscado.
    * @return MovieDetailsResponse objeto contendo informações detalhadas do filme encontrado.
-   * @throws MovieNotFoundException caso o filme não seja encontrado para o dado {@code id}.
+   * @throws MovieNotFoundException caso o filme não seja encontrado para o dado {@code movieId}.
    */
-  MovieDetailsResponse findById(@NotBlank(message = "{MovieService.findById.movieId.NotBlank.message}") String movieId);
+  MovieDetailsResponse findDetailedById(@NotBlank(message = "{MovieService.findById.movieId.NotBlank.message}") String movieId);
+
+  /**
+   * Busca informações resumidas do Movie por id.
+   *
+   * @param movieId identificador do filme a ser buscado.
+   * @return MovieSummaryResponse objeto contendo informações resumidas do filme encontrado.
+   * @throws MovieNotFoundException caso o filme não seja encontrado para o dado {@code movieId}.
+   */
+  MovieSummaryResponse findSummarizedById(@NotBlank(message = "{MovieService.findById.movieId.NotBlank.message}") String movieId);
 
 }

--- a/src/main/java/br/com/emendes/yourreviewapi/service/ReviewService.java
+++ b/src/main/java/br/com/emendes/yourreviewapi/service/ReviewService.java
@@ -3,6 +3,7 @@ package br.com.emendes.yourreviewapi.service;
 import br.com.emendes.yourreviewapi.dto.request.ReviewRegisterRequest;
 import br.com.emendes.yourreviewapi.dto.request.ReviewUpdateRequest;
 import br.com.emendes.yourreviewapi.dto.response.ReviewDetailsResponse;
+import br.com.emendes.yourreviewapi.dto.response.ReviewResponse;
 import br.com.emendes.yourreviewapi.dto.response.ReviewSummaryResponse;
 import br.com.emendes.yourreviewapi.exception.ReviewNotFoundException;
 import br.com.emendes.yourreviewapi.model.entity.Review;
@@ -25,7 +26,7 @@ public interface ReviewService {
    * @param reviewRegisterRequest objeto DTO contendo os dados para criação da Review.
    * @return ReviewDetailResponse contendo informações detalhadas da Review cadastrada.
    */
-  ReviewDetailsResponse register(@Valid ReviewRegisterRequest reviewRegisterRequest);
+  ReviewResponse register(@Valid ReviewRegisterRequest reviewRegisterRequest);
 
 
   /**
@@ -43,7 +44,7 @@ public interface ReviewService {
    * Buscar {@link Review} por id.
    *
    * @param reviewId identificador da review a ser buscada.
-   * @return Objeto {@link ReviewDetailsResponse} contendo informações da Review.
+   * @return Objeto {@link ReviewResponse} contendo informações da Review.
    * @throws ReviewNotFoundException caso não seja encontrada review para o dado reviewId.
    */
   ReviewDetailsResponse findById(@NotNull(message = "{ReviewService.findById.reviewId.NotNull.message}") Long reviewId);
@@ -53,10 +54,10 @@ public interface ReviewService {
    *
    * @param reviewId            identificador da review a ser atualizada.
    * @param reviewUpdateRequest objeto com os novos dados da Review.
-   * @return Objeto ReviewDetailsResponse com os dados atualizados.
+   * @return Objeto ReviewResponse com os dados atualizados.
    * @throws ReviewNotFoundException caso não seja encontrada review para o dado reviewId.
    */
-  ReviewDetailsResponse updateById(
+  ReviewResponse updateById(
       @NotNull(message = "{ReviewService.findById.reviewId.NotNull.message}") Long reviewId,
       @Valid ReviewUpdateRequest reviewUpdateRequest);
 

--- a/src/main/java/br/com/emendes/yourreviewapi/service/impl/MovieServiceImpl.java
+++ b/src/main/java/br/com/emendes/yourreviewapi/service/impl/MovieServiceImpl.java
@@ -29,10 +29,17 @@ public class MovieServiceImpl implements MovieService {
   }
 
   @Override
-  public MovieDetailsResponse findById(String movieId) {
+  public MovieDetailsResponse findDetailedById(String movieId) {
     log.info("Searching for movie with id: {}", movieId);
 
     return movieMapper.toMovieDetailsResponse(movieClient.findById(movieId));
+  }
+
+  @Override
+  public MovieSummaryResponse findSummarizedById(String movieId) {
+    log.info("Searching for movie with id: {}", movieId);
+
+    return movieMapper.toMovieSummaryResponse(movieClient.findById(movieId));
   }
 
 }

--- a/src/test/java/br/com/emendes/yourreviewapi/integration/controller/ReviewControllerIT.java
+++ b/src/test/java/br/com/emendes/yourreviewapi/integration/controller/ReviewControllerIT.java
@@ -2,16 +2,18 @@ package br.com.emendes.yourreviewapi.integration.controller;
 
 import br.com.emendes.yourreviewapi.controller.ReviewController;
 import br.com.emendes.yourreviewapi.dto.response.ReviewDetailsResponse;
+import br.com.emendes.yourreviewapi.dto.response.ReviewResponse;
 import br.com.emendes.yourreviewapi.dto.response.ReviewSummaryResponse;
 import br.com.emendes.yourreviewapi.exception.UserIsNotAuthenticatedException;
 import br.com.emendes.yourreviewapi.mapper.ReviewMapper;
 import br.com.emendes.yourreviewapi.model.entity.Review;
 import br.com.emendes.yourreviewapi.repository.ReviewRepository;
-import br.com.emendes.yourreviewapi.repository.projection.ReviewDetailsProjection;
+import br.com.emendes.yourreviewapi.service.MovieService;
 import br.com.emendes.yourreviewapi.service.MovieVotesService;
 import br.com.emendes.yourreviewapi.service.ReviewService;
 import br.com.emendes.yourreviewapi.util.PageableResponse;
 import br.com.emendes.yourreviewapi.util.component.AuthenticatedUserComponent;
+import br.com.emendes.yourreviewapi.util.faker.MovieFaker;
 import br.com.emendes.yourreviewapi.util.faker.MovieVotesFaker;
 import br.com.emendes.yourreviewapi.util.faker.ReviewFaker;
 import br.com.emendes.yourreviewapi.util.faker.UserFaker;
@@ -63,6 +65,8 @@ class ReviewControllerIT {
   @MockBean
   private MovieVotesService movieVotesServiceMock;
   @MockBean
+  private MovieService movieServiceMock;
+  @MockBean
   private ReviewMapper reviewMapperMock;
   @MockBean
   private ReviewRepository reviewRepositoryMock;
@@ -83,7 +87,7 @@ class ReviewControllerIT {
       when(movieVotesServiceMock.findByMovieId("1000000")).thenReturn(MovieVotesFaker.movieVotesOptional());
       when(reviewMapperMock.toReview(any())).thenReturn(ReviewFaker.nonRegisteredReview());
       when(reviewRepositoryMock.save(any())).thenReturn(ReviewFaker.review());
-      when(reviewMapperMock.toReviewDetailsResponse(any(Review.class))).thenReturn(ReviewFaker.reviewDetailsResponse());
+      when(reviewMapperMock.toReviewResponse(any(Review.class))).thenReturn(ReviewFaker.reviewResponse());
 
       String requestBody = """
           {
@@ -105,7 +109,7 @@ class ReviewControllerIT {
       when(movieVotesServiceMock.findByMovieId("1000000")).thenReturn(MovieVotesFaker.movieVotesOptional());
       when(reviewMapperMock.toReview(any())).thenReturn(ReviewFaker.nonRegisteredReview());
       when(reviewRepositoryMock.save(any())).thenReturn(ReviewFaker.review());
-      when(reviewMapperMock.toReviewDetailsResponse(any(Review.class))).thenReturn(ReviewFaker.reviewDetailsResponse());
+      when(reviewMapperMock.toReviewResponse(any(Review.class))).thenReturn(ReviewFaker.reviewResponse());
 
       String requestBody = """
           {
@@ -118,7 +122,7 @@ class ReviewControllerIT {
       String actualContent = mockMvc.perform(post(REGISTER_URI).contentType(CONTENT_TYPE).content(requestBody))
           .andReturn().getResponse().getContentAsString();
 
-      ReviewDetailsResponse actualResponseBody = mapper.readValue(actualContent, ReviewDetailsResponse.class);
+      ReviewResponse actualResponseBody = mapper.readValue(actualContent, ReviewResponse.class);
 
       assertThat(actualResponseBody).isNotNull();
       assertThat(actualResponseBody.id()).isNotNull().isEqualTo(2_000_000L);
@@ -139,7 +143,7 @@ class ReviewControllerIT {
           .thenReturn(MovieVotesFaker.nonRegisteredMovieVotes());
       when(reviewMapperMock.toReview(any())).thenReturn(ReviewFaker.nonRegisteredReview());
       when(reviewRepositoryMock.save(any())).thenReturn(ReviewFaker.review());
-      when(reviewMapperMock.toReviewDetailsResponse(any(Review.class))).thenReturn(ReviewFaker.reviewDetailsResponse());
+      when(reviewMapperMock.toReviewResponse(any(Review.class))).thenReturn(ReviewFaker.reviewResponse());
 
       String requestBody = """
           {
@@ -163,7 +167,7 @@ class ReviewControllerIT {
           .thenReturn(MovieVotesFaker.nonRegisteredMovieVotes());
       when(reviewMapperMock.toReview(any())).thenReturn(ReviewFaker.nonRegisteredReview());
       when(reviewRepositoryMock.save(any())).thenReturn(ReviewFaker.review());
-      when(reviewMapperMock.toReviewDetailsResponse(any(Review.class))).thenReturn(ReviewFaker.reviewDetailsResponse());
+      when(reviewMapperMock.toReviewResponse(any(Review.class))).thenReturn(ReviewFaker.reviewResponse());
 
       String requestBody = """
           {
@@ -176,7 +180,7 @@ class ReviewControllerIT {
       String actualContent = mockMvc.perform(post(REGISTER_URI).contentType(CONTENT_TYPE).content(requestBody))
           .andReturn().getResponse().getContentAsString();
 
-      ReviewDetailsResponse actualResponseBody = mapper.readValue(actualContent, ReviewDetailsResponse.class);
+      ReviewResponse actualResponseBody = mapper.readValue(actualContent, ReviewResponse.class);
 
       assertThat(actualResponseBody).isNotNull();
       assertThat(actualResponseBody.id()).isNotNull().isEqualTo(2_000_000L);
@@ -194,8 +198,8 @@ class ReviewControllerIT {
       when(movieVotesServiceMock.findByMovieId("1000000")).thenReturn(MovieVotesFaker.movieVotesOptional());
       when(reviewMapperMock.toReview(any())).thenReturn(ReviewFaker.nonRegisteredReviewWithoutOpinion());
       when(reviewRepositoryMock.save(any())).thenReturn(ReviewFaker.reviewWithoutOpinion());
-      when(reviewMapperMock.toReviewDetailsResponse(any(Review.class)))
-          .thenReturn(ReviewFaker.reviewDetailsResponseWithoutOpinion());
+      when(reviewMapperMock.toReviewResponse(any(Review.class)))
+          .thenReturn(ReviewFaker.reviewResponseWithoutOpinion());
 
       String requestBody = """
           {
@@ -216,8 +220,8 @@ class ReviewControllerIT {
       when(movieVotesServiceMock.findByMovieId("1000000")).thenReturn(MovieVotesFaker.movieVotesOptional());
       when(reviewMapperMock.toReview(any())).thenReturn(ReviewFaker.nonRegisteredReviewWithoutOpinion());
       when(reviewRepositoryMock.save(any())).thenReturn(ReviewFaker.reviewWithoutOpinion());
-      when(reviewMapperMock.toReviewDetailsResponse(any(Review.class)))
-          .thenReturn(ReviewFaker.reviewDetailsResponseWithoutOpinion());
+      when(reviewMapperMock.toReviewResponse(any(Review.class)))
+          .thenReturn(ReviewFaker.reviewResponseWithoutOpinion());
 
       String requestBody = """
           {
@@ -229,7 +233,7 @@ class ReviewControllerIT {
       String actualContent = mockMvc.perform(post(REGISTER_URI).contentType(CONTENT_TYPE).content(requestBody))
           .andReturn().getResponse().getContentAsString();
 
-      ReviewDetailsResponse actualResponseBody = mapper.readValue(actualContent, ReviewDetailsResponse.class);
+      ReviewResponse actualResponseBody = mapper.readValue(actualContent, ReviewResponse.class);
 
       assertThat(actualResponseBody).isNotNull();
       assertThat(actualResponseBody.id()).isNotNull().isEqualTo(2_000_000L);
@@ -504,10 +508,11 @@ class ReviewControllerIT {
     void findById_MustReturnStatus200_WhenFetchSuccessfully() throws Exception {
       when(reviewRepositoryMock.findProjectedById(any()))
           .thenReturn(ReviewFaker.reviewDetailsProjectionOptional());
-      when(reviewMapperMock.toReviewDetailsResponse(any(ReviewDetailsProjection.class)))
+      when(movieServiceMock.findSummarizedById("1000000")).thenReturn(MovieFaker.movieSummaryResponse());
+      when(reviewMapperMock.toReviewDetailsResponse(any(), any()))
           .thenReturn(ReviewFaker.reviewDetailsResponse());
 
-      mockMvc.perform(get(FETCH_BY_MOVIE_ID_URI, "2000000").contentType(CONTENT_TYPE))
+      mockMvc.perform(get(FETCH_BY_MOVIE_ID_URI, "1000000000").contentType(CONTENT_TYPE))
           .andExpect(status().isOk());
     }
 
@@ -516,20 +521,25 @@ class ReviewControllerIT {
     void findById_MustReturnReviewDetailsResponse_WhenFetchSuccessfully() throws Exception {
       when(reviewRepositoryMock.findProjectedById(any()))
           .thenReturn(ReviewFaker.reviewDetailsProjectionOptional());
-      when(reviewMapperMock.toReviewDetailsResponse(any(ReviewDetailsProjection.class)))
+      when(movieServiceMock.findSummarizedById("1000000")).thenReturn(MovieFaker.movieSummaryResponse());
+      when(reviewMapperMock.toReviewDetailsResponse(any(), any()))
           .thenReturn(ReviewFaker.reviewDetailsResponse());
 
-      String actualContent = mockMvc.perform(get(FETCH_BY_MOVIE_ID_URI, "2000000").contentType(CONTENT_TYPE))
+      String actualContent = mockMvc.perform(get(FETCH_BY_MOVIE_ID_URI, "1000000000").contentType(CONTENT_TYPE))
           .andReturn().getResponse().getContentAsString();
 
       ReviewDetailsResponse actualResponseBody = mapper.readValue(actualContent, ReviewDetailsResponse.class);
 
       assertThat(actualResponseBody).isNotNull();
-      assertThat(actualResponseBody.id()).isNotNull().isEqualTo(2_000_000L);
+      assertThat(actualResponseBody.id()).isNotNull().isEqualTo(1_000_000_000L);
       assertThat(actualResponseBody.vote()).isEqualTo(9);
       assertThat(actualResponseBody.opinion()).isNotNull().isEqualTo("Lorem ipsum dolor sit amet");
       assertThat(actualResponseBody.userId()).isNotNull().isEqualTo(100L);
-      assertThat(actualResponseBody.movieId()).isNotNull().isEqualTo("1000000");
+      assertThat(actualResponseBody.movie()).isNotNull();
+      assertThat(actualResponseBody.movie().id()).isNotNull().isEqualTo("1000000");
+      assertThat(actualResponseBody.movie().title()).isNotNull().isEqualTo("Lorem");
+      assertThat(actualResponseBody.movie().posterPath()).isNotNull().isEqualTo("/1000000");
+      assertThat(actualResponseBody.movie().releaseDate()).isNotNull().isEqualTo("2024-01-16");
     }
 
     @Test
@@ -571,8 +581,8 @@ class ReviewControllerIT {
       when(authenticatedUserComponentMock.getCurrentUser()).thenReturn(UserFaker.user());
       when(reviewRepositoryMock.findByIdAndUserId(any(), any())).thenReturn(ReviewFaker.reviewOptional());
       when(reviewRepositoryMock.save(any())).thenReturn(ReviewFaker.reviewUpdated());
-      when(reviewMapperMock.toReviewDetailsResponse(any(Review.class)))
-          .thenReturn(ReviewFaker.reviewDetailsResponseUpdated());
+      when(reviewMapperMock.toReviewResponse(any(Review.class)))
+          .thenReturn(ReviewFaker.reviewResponseUpdated());
 
       String requestBody = """
           {
@@ -591,8 +601,8 @@ class ReviewControllerIT {
       when(authenticatedUserComponentMock.getCurrentUser()).thenReturn(UserFaker.user());
       when(reviewRepositoryMock.findByIdAndUserId(any(), any())).thenReturn(ReviewFaker.reviewOptional());
       when(reviewRepositoryMock.save(any())).thenReturn(ReviewFaker.reviewUpdated());
-      when(reviewMapperMock.toReviewDetailsResponse(any(Review.class)))
-          .thenReturn(ReviewFaker.reviewDetailsResponseUpdated());
+      when(reviewMapperMock.toReviewResponse(any(Review.class)))
+          .thenReturn(ReviewFaker.reviewResponseUpdated());
 
       String requestBody = """
           {
@@ -604,7 +614,7 @@ class ReviewControllerIT {
       String actualContent = mockMvc.perform(put(UPDATE_BY_ID_URI, "2000000").contentType(CONTENT_TYPE).content(requestBody))
           .andReturn().getResponse().getContentAsString();
 
-      ReviewDetailsResponse actualResponseBody = mapper.readValue(actualContent, ReviewDetailsResponse.class);
+      ReviewResponse actualResponseBody = mapper.readValue(actualContent, ReviewResponse.class);
 
       assertThat(actualResponseBody).isNotNull();
       assertThat(actualResponseBody.id()).isNotNull().isEqualTo(2_000_000L);
@@ -621,8 +631,8 @@ class ReviewControllerIT {
       when(authenticatedUserComponentMock.getCurrentUser()).thenReturn(UserFaker.user());
       when(reviewRepositoryMock.findByIdAndUserId(any(), any())).thenReturn(ReviewFaker.reviewOptional());
       when(reviewRepositoryMock.save(any())).thenReturn(ReviewFaker.reviewUpdatedWithoutOpinion());
-      when(reviewMapperMock.toReviewDetailsResponse(any(Review.class)))
-          .thenReturn(ReviewFaker.reviewDetailsResponseUpdatedWithoutOpinion());
+      when(reviewMapperMock.toReviewResponse(any(Review.class)))
+          .thenReturn(ReviewFaker.reviewResponseUpdatedWithoutOpinion());
 
       String requestBody = """
           {
@@ -640,8 +650,8 @@ class ReviewControllerIT {
       when(authenticatedUserComponentMock.getCurrentUser()).thenReturn(UserFaker.user());
       when(reviewRepositoryMock.findByIdAndUserId(any(), any())).thenReturn(ReviewFaker.reviewOptional());
       when(reviewRepositoryMock.save(any())).thenReturn(ReviewFaker.reviewUpdatedWithoutOpinion());
-      when(reviewMapperMock.toReviewDetailsResponse(any(Review.class)))
-          .thenReturn(ReviewFaker.reviewDetailsResponseUpdatedWithoutOpinion());
+      when(reviewMapperMock.toReviewResponse(any(Review.class)))
+          .thenReturn(ReviewFaker.reviewResponseUpdatedWithoutOpinion());
 
       String requestBody = """
           {
@@ -652,7 +662,7 @@ class ReviewControllerIT {
       String actualContent = mockMvc.perform(put(UPDATE_BY_ID_URI, "2000000").contentType(CONTENT_TYPE).content(requestBody))
           .andReturn().getResponse().getContentAsString();
 
-      ReviewDetailsResponse actualResponseBody = mapper.readValue(actualContent, ReviewDetailsResponse.class);
+      ReviewResponse actualResponseBody = mapper.readValue(actualContent, ReviewResponse.class);
 
       assertThat(actualResponseBody).isNotNull();
       assertThat(actualResponseBody.id()).isNotNull().isEqualTo(2_000_000L);

--- a/src/test/java/br/com/emendes/yourreviewapi/unit/mapper/impl/ReviewMapperImplTest.java
+++ b/src/test/java/br/com/emendes/yourreviewapi/unit/mapper/impl/ReviewMapperImplTest.java
@@ -1,12 +1,15 @@
 package br.com.emendes.yourreviewapi.unit.mapper.impl;
 
 import br.com.emendes.yourreviewapi.dto.request.ReviewRegisterRequest;
+import br.com.emendes.yourreviewapi.dto.response.MovieSummaryResponse;
 import br.com.emendes.yourreviewapi.dto.response.ReviewDetailsResponse;
+import br.com.emendes.yourreviewapi.dto.response.ReviewResponse;
 import br.com.emendes.yourreviewapi.dto.response.ReviewSummaryResponse;
 import br.com.emendes.yourreviewapi.mapper.impl.ReviewMapperImpl;
 import br.com.emendes.yourreviewapi.model.entity.Review;
 import br.com.emendes.yourreviewapi.repository.projection.ReviewDetailsProjection;
 import br.com.emendes.yourreviewapi.repository.projection.ReviewSummaryProjection;
+import br.com.emendes.yourreviewapi.util.faker.MovieFaker;
 import br.com.emendes.yourreviewapi.util.faker.MovieVotesFaker;
 import br.com.emendes.yourreviewapi.util.faker.UserFaker;
 import br.com.emendes.yourreviewapi.util.projection.impl.ReviewDetailsProjectionImpl;
@@ -87,8 +90,8 @@ class ReviewMapperImplTest {
   }
 
   @Test
-  @DisplayName("toReviewDetailsResponse must return ReviewDetailsResponse when map Review successfully")
-  void toReviewDetailsResponse_MustReturnReviewDetailsResponse_WhenMapSuccessfully() {
+  @DisplayName("toReviewResponse must return ReviewResponse when map Review successfully")
+  void toReviewResponse_MustReturnReviewResponse_WhenMapSuccessfully() {
     Review review = Review.builder()
         .id(1_000_000_000L)
         .vote(9)
@@ -98,22 +101,22 @@ class ReviewMapperImplTest {
         .movieVotes(MovieVotesFaker.movieVotes())
         .build();
 
-    ReviewDetailsResponse actualReviewDetailsResponse = reviewMapper.toReviewDetailsResponse(review);
+    ReviewResponse actualReviewResponse = reviewMapper.toReviewResponse(review);
 
-    assertThat(actualReviewDetailsResponse).isNotNull();
-    assertThat(actualReviewDetailsResponse.id()).isNotNull().isEqualTo(1_000_000_000L);
-    assertThat(actualReviewDetailsResponse.vote()).isEqualTo(9);
-    assertThat(actualReviewDetailsResponse.opinion()).isNotNull().isEqualTo("Lorem ipsum dolor sit amet");
-    assertThat(actualReviewDetailsResponse.createdAt()).isNotNull().isEqualTo("2024-02-08T10:00:00");
-    assertThat(actualReviewDetailsResponse.userId()).isNotNull().isEqualTo(100L);
-    assertThat(actualReviewDetailsResponse.movieId()).isNotNull().isEqualTo("1000000");
+    assertThat(actualReviewResponse).isNotNull();
+    assertThat(actualReviewResponse.id()).isNotNull().isEqualTo(1_000_000_000L);
+    assertThat(actualReviewResponse.vote()).isEqualTo(9);
+    assertThat(actualReviewResponse.opinion()).isNotNull().isEqualTo("Lorem ipsum dolor sit amet");
+    assertThat(actualReviewResponse.createdAt()).isNotNull().isEqualTo("2024-02-08T10:00:00");
+    assertThat(actualReviewResponse.userId()).isNotNull().isEqualTo(100L);
+    assertThat(actualReviewResponse.movieId()).isNotNull().isEqualTo("1000000");
   }
 
   @Test
-  @DisplayName("toReviewDetailsResponse must throw IllegalArgumentException when review parameter is null")
-  void toReviewDetailsResponse_MustThrowIllegalArgumentException_WhenReviewParameterIsNull() {
+  @DisplayName("toReviewResponse must throw IllegalArgumentException when review parameter is null")
+  void toReviewResponse_MustThrowIllegalArgumentException_WhenReviewParameterIsNull() {
     assertThatExceptionOfType(IllegalArgumentException.class)
-        .isThrownBy(() -> reviewMapper.toReviewDetailsResponse((Review) null))
+        .isThrownBy(() -> reviewMapper.toReviewResponse(null))
         .withMessage("review must not be null");
   }
 
@@ -129,7 +132,8 @@ class ReviewMapperImplTest {
         .movieVotesMovieId("1000000")
         .build();
 
-    ReviewDetailsResponse actualReviewDetailsResponse = reviewMapper.toReviewDetailsResponse(reviewDetailsProjection);
+    ReviewDetailsResponse actualReviewDetailsResponse = reviewMapper
+        .toReviewDetailsResponse(reviewDetailsProjection, MovieFaker.movieSummaryResponse());
 
     assertThat(actualReviewDetailsResponse).isNotNull();
     assertThat(actualReviewDetailsResponse.id()).isNotNull().isEqualTo(1_000_000_000L);
@@ -137,15 +141,38 @@ class ReviewMapperImplTest {
     assertThat(actualReviewDetailsResponse.opinion()).isNotNull().isEqualTo("Lorem ipsum dolor sit amet");
     assertThat(actualReviewDetailsResponse.createdAt()).isNotNull().isEqualTo("2024-02-08T10:00:00");
     assertThat(actualReviewDetailsResponse.userId()).isNotNull().isEqualTo(100L);
-    assertThat(actualReviewDetailsResponse.movieId()).isNotNull().isEqualTo("1000000");
+    assertThat(actualReviewDetailsResponse.movie()).isNotNull();
+    assertThat(actualReviewDetailsResponse.movie().id()).isNotNull().isEqualTo("1000000");
+    assertThat(actualReviewDetailsResponse.movie().title()).isNotNull().isEqualTo("Lorem");
+    assertThat(actualReviewDetailsResponse.movie().posterPath()).isNotNull().isEqualTo("/1000000");
+    assertThat(actualReviewDetailsResponse.movie().releaseDate()).isNotNull().isEqualTo("2024-01-16");
   }
 
   @Test
   @DisplayName("toReviewDetailsResponse must throw IllegalArgumentException when reviewDetailsProjection parameter is null")
   void toReviewDetailsResponse_MustThrowIllegalArgumentException_WhenReviewDetailsProjectionParameterIsNull() {
+    MovieSummaryResponse movieSummaryResponse = MovieFaker.movieSummaryResponse();
+
     assertThatExceptionOfType(IllegalArgumentException.class)
-        .isThrownBy(() -> reviewMapper.toReviewDetailsResponse((ReviewDetailsProjection) null))
+        .isThrownBy(() -> reviewMapper.toReviewDetailsResponse(null, movieSummaryResponse))
         .withMessage("reviewDetailsProjection must not be null");
+  }
+
+  @Test
+  @DisplayName("toReviewDetailsResponse must throw IllegalArgumentException when movie parameter is null")
+  void toReviewDetailsResponse_MustThrowIllegalArgumentException_WhenMovieParameterIsNull() {
+    ReviewDetailsProjection reviewDetailsProjection = ReviewDetailsProjectionImpl.builder()
+        .id(1_000_000_000L)
+        .vote(9)
+        .opinion("Lorem ipsum dolor sit amet")
+        .createdAt(LocalDateTime.parse("2024-02-08T10:00:00"))
+        .userId(100L)
+        .movieVotesMovieId("1000000")
+        .build();
+
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> reviewMapper.toReviewDetailsResponse(reviewDetailsProjection, null))
+        .withMessage("movie must not be null");
   }
 
 }

--- a/src/test/java/br/com/emendes/yourreviewapi/unit/service/impl/MovieServiceImplTest.java
+++ b/src/test/java/br/com/emendes/yourreviewapi/unit/service/impl/MovieServiceImplTest.java
@@ -3,6 +3,7 @@ package br.com.emendes.yourreviewapi.unit.service.impl;
 import br.com.emendes.yourreviewapi.client.MovieClient;
 import br.com.emendes.yourreviewapi.dto.response.MovieDetailsResponse;
 import br.com.emendes.yourreviewapi.dto.response.MovieSummaryResponse;
+import br.com.emendes.yourreviewapi.exception.MovieNotFoundException;
 import br.com.emendes.yourreviewapi.mapper.MovieMapper;
 import br.com.emendes.yourreviewapi.model.Movie;
 import br.com.emendes.yourreviewapi.service.impl.MovieServiceImpl;
@@ -51,18 +52,18 @@ class MovieServiceImplTest {
   }
 
   @Nested
-  @DisplayName("Tests for findById method")
-  class FindByIdMethod {
+  @DisplayName("Tests for findDetailedById method")
+  class FindDetailedByIdMethod {
 
     @Test
-    @DisplayName("findById must return MovieDetailsResponse when found successfully")
-    void findById_MustReturnMovieDetailsResponse_WhenFoundSuccessfully() {
+    @DisplayName("findDetailedById must return MovieDetailsResponse when found successfully")
+    void findDetailedById_MustReturnMovieDetailsResponse_WhenFoundSuccessfully() {
       when(movieClientMock.findById("1000000"))
           .thenReturn(MovieFaker.movie());
       when(movieMapperMock.toMovieDetailsResponse(any(Movie.class)))
           .thenReturn(MovieFaker.movieDetailsResponse());
 
-      MovieDetailsResponse actualMovieDetailsResponse = movieService.findById("1000000");
+      MovieDetailsResponse actualMovieDetailsResponse = movieService.findDetailedById("1000000");
 
       Assertions.assertThat(actualMovieDetailsResponse).isNotNull();
       Assertions.assertThat(actualMovieDetailsResponse.id()).isNotNull().isEqualTo("1000000");
@@ -72,6 +73,49 @@ class MovieServiceImplTest {
       Assertions.assertThat(actualMovieDetailsResponse.posterPath()).isNotNull().isEqualTo("/1000000");
       Assertions.assertThat(actualMovieDetailsResponse.releaseDate()).isNotNull().isEqualTo("2024-01-16");
       Assertions.assertThat(actualMovieDetailsResponse.originalLanguage()).isNotNull().isEqualTo("en");
+    }
+
+    @Test
+    @DisplayName("findDetailedById must throw MovieNotFoundException when not found Movie for given movieId")
+    void findDetailedById_MustThrowMovieNotFoundException_WhenNotFoundMovieForGivenMovieId() {
+      when(movieClientMock.findById("1000000")).thenThrow(new MovieNotFoundException("movie not found with id: 1000000"));
+
+      Assertions.assertThatExceptionOfType(MovieNotFoundException.class)
+          .isThrownBy(() -> movieService.findDetailedById("1000000"))
+          .withMessage("movie not found with id: 1000000");
+    }
+
+  }
+
+  @Nested
+  @DisplayName("Tests for findSummarizedById method")
+  class FindSummarizedByIdMethod {
+
+    @Test
+    @DisplayName("findSummarizedById must return MovieSummaryResponse when found successfully")
+    void findSummarizedById_MustReturnMovieSummaryResponse_WhenFoundSuccessfully() {
+      when(movieClientMock.findById("1000000"))
+          .thenReturn(MovieFaker.movie());
+      when(movieMapperMock.toMovieSummaryResponse(any(Movie.class)))
+          .thenReturn(MovieFaker.movieSummaryResponse());
+
+      MovieSummaryResponse actualMovieSummaryResponse = movieService.findSummarizedById("1000000");
+
+      Assertions.assertThat(actualMovieSummaryResponse).isNotNull();
+      Assertions.assertThat(actualMovieSummaryResponse.id()).isNotNull().isEqualTo("1000000");
+      Assertions.assertThat(actualMovieSummaryResponse.title()).isNotNull().isEqualTo("Lorem");
+      Assertions.assertThat(actualMovieSummaryResponse.posterPath()).isNotNull().isEqualTo("/1000000");
+      Assertions.assertThat(actualMovieSummaryResponse.releaseDate()).isNotNull().isEqualTo("2024-01-16");
+    }
+
+    @Test
+    @DisplayName("findSummarizedById must throw MovieNotFoundException when not found Movie for given movieId")
+    void findSummarizedById_MustThrowMovieNotFoundException_WhenNotFoundMovieForGivenMovieId() {
+      when(movieClientMock.findById("1000000")).thenThrow(new MovieNotFoundException("movie not found with id: 1000000"));
+
+      Assertions.assertThatExceptionOfType(MovieNotFoundException.class)
+          .isThrownBy(() -> movieService.findSummarizedById("1000000"))
+          .withMessage("movie not found with id: 1000000");
     }
 
   }

--- a/src/test/java/br/com/emendes/yourreviewapi/unit/service/impl/ReviewServiceImplTest.java
+++ b/src/test/java/br/com/emendes/yourreviewapi/unit/service/impl/ReviewServiceImplTest.java
@@ -1,7 +1,7 @@
 package br.com.emendes.yourreviewapi.unit.service.impl;
 
 import br.com.emendes.yourreviewapi.dto.request.ReviewRegisterRequest;
-import br.com.emendes.yourreviewapi.dto.response.ReviewDetailsResponse;
+import br.com.emendes.yourreviewapi.dto.response.ReviewResponse;
 import br.com.emendes.yourreviewapi.dto.response.ReviewSummaryResponse;
 import br.com.emendes.yourreviewapi.exception.ReviewAlreadyExistsException;
 import br.com.emendes.yourreviewapi.mapper.ReviewMapper;
@@ -49,14 +49,14 @@ class ReviewServiceImplTest {
   class RegisterMethod {
 
     @Test
-    @DisplayName("register must return ReviewDetailsResponse when MovieVotes already exists and register successfully")
+    @DisplayName("register must return ReviewResponse when MovieVotes already exists and register successfully")
     void register_MustReturnReviewDetailsResponse_WhenMovieVotesAlreadyExistsAndRegisterSuccessfully() {
       when(authenticatedUserComponentMock.getCurrentUser()).thenReturn(UserFaker.user());
       when(reviewRepositoryMock.existsByUserIdAndMovieId(100L, "1000000")).thenReturn(false);
       when(movieVotesServiceMock.findByMovieId("1000000")).thenReturn(MovieVotesFaker.movieVotesOptional());
       when(reviewMapperMock.toReview(any())).thenReturn(ReviewFaker.nonRegisteredReview());
       when(reviewRepositoryMock.save(any())).thenReturn(ReviewFaker.review());
-      when(reviewMapperMock.toReviewDetailsResponse(any(Review.class))).thenReturn(ReviewFaker.reviewDetailsResponse());
+      when(reviewMapperMock.toReviewResponse(any(Review.class))).thenReturn(ReviewFaker.reviewResponse());
 
       ReviewRegisterRequest reviewRegisterRequest = ReviewRegisterRequest.builder()
           .vote(9)
@@ -64,19 +64,19 @@ class ReviewServiceImplTest {
           .movieId("1000000")
           .build();
 
-      ReviewDetailsResponse actualReviewDetailsResponse = reviewService.register(reviewRegisterRequest);
+      ReviewResponse actualReviewResponse = reviewService.register(reviewRegisterRequest);
 
-      assertThat(actualReviewDetailsResponse).isNotNull();
-      assertThat(actualReviewDetailsResponse.id()).isNotNull().isEqualTo(2_000_000L);
-      assertThat(actualReviewDetailsResponse.vote()).isEqualTo(9);
-      assertThat(actualReviewDetailsResponse.opinion()).isNotNull().isEqualTo("Lorem ipsum dolor sit amet");
-      assertThat(actualReviewDetailsResponse.userId()).isNotNull().isEqualTo(100L);
-      assertThat(actualReviewDetailsResponse.movieId()).isNotNull().isEqualTo("1000000");
-      assertThat(actualReviewDetailsResponse.createdAt()).isNotNull().isEqualTo("2024-02-09T10:00:00");
+      assertThat(actualReviewResponse).isNotNull();
+      assertThat(actualReviewResponse.id()).isNotNull().isEqualTo(2_000_000L);
+      assertThat(actualReviewResponse.vote()).isEqualTo(9);
+      assertThat(actualReviewResponse.opinion()).isNotNull().isEqualTo("Lorem ipsum dolor sit amet");
+      assertThat(actualReviewResponse.userId()).isNotNull().isEqualTo(100L);
+      assertThat(actualReviewResponse.movieId()).isNotNull().isEqualTo("1000000");
+      assertThat(actualReviewResponse.createdAt()).isNotNull().isEqualTo("2024-02-09T10:00:00");
     }
 
     @Test
-    @DisplayName("register must return ReviewDetailsResponse when MovieVotes non exists and register successfully")
+    @DisplayName("register must return ReviewResponse when MovieVotes non exists and register successfully")
     void register_MustReturnReviewDetailsResponse_WhenMovieVotesNonExistsAndRegisterSuccessfully() {
       when(authenticatedUserComponentMock.getCurrentUser()).thenReturn(UserFaker.user());
       when(reviewRepositoryMock.existsByUserIdAndMovieId(100L, "1000000")).thenReturn(false);
@@ -85,7 +85,7 @@ class ReviewServiceImplTest {
           .thenReturn(MovieVotesFaker.nonRegisteredMovieVotes());
       when(reviewMapperMock.toReview(any())).thenReturn(ReviewFaker.nonRegisteredReview());
       when(reviewRepositoryMock.save(any())).thenReturn(ReviewFaker.review());
-      when(reviewMapperMock.toReviewDetailsResponse(any(Review.class))).thenReturn(ReviewFaker.reviewDetailsResponse());
+      when(reviewMapperMock.toReviewResponse(any(Review.class))).thenReturn(ReviewFaker.reviewResponse());
 
       ReviewRegisterRequest reviewRegisterRequest = ReviewRegisterRequest.builder()
           .vote(9)
@@ -93,15 +93,15 @@ class ReviewServiceImplTest {
           .movieId("1000000")
           .build();
 
-      ReviewDetailsResponse actualReviewDetailsResponse = reviewService.register(reviewRegisterRequest);
+      ReviewResponse actualReviewResponse = reviewService.register(reviewRegisterRequest);
 
-      assertThat(actualReviewDetailsResponse).isNotNull();
-      assertThat(actualReviewDetailsResponse.id()).isNotNull().isEqualTo(2_000_000L);
-      assertThat(actualReviewDetailsResponse.vote()).isEqualTo(9);
-      assertThat(actualReviewDetailsResponse.opinion()).isNotNull().isEqualTo("Lorem ipsum dolor sit amet");
-      assertThat(actualReviewDetailsResponse.userId()).isNotNull().isEqualTo(100L);
-      assertThat(actualReviewDetailsResponse.movieId()).isNotNull().isEqualTo("1000000");
-      assertThat(actualReviewDetailsResponse.createdAt()).isNotNull().isEqualTo("2024-02-09T10:00:00");
+      assertThat(actualReviewResponse).isNotNull();
+      assertThat(actualReviewResponse.id()).isNotNull().isEqualTo(2_000_000L);
+      assertThat(actualReviewResponse.vote()).isEqualTo(9);
+      assertThat(actualReviewResponse.opinion()).isNotNull().isEqualTo("Lorem ipsum dolor sit amet");
+      assertThat(actualReviewResponse.userId()).isNotNull().isEqualTo(100L);
+      assertThat(actualReviewResponse.movieId()).isNotNull().isEqualTo("1000000");
+      assertThat(actualReviewResponse.createdAt()).isNotNull().isEqualTo("2024-02-09T10:00:00");
     }
 
     @Test

--- a/src/test/java/br/com/emendes/yourreviewapi/util/faker/ReviewFaker.java
+++ b/src/test/java/br/com/emendes/yourreviewapi/util/faker/ReviewFaker.java
@@ -1,6 +1,7 @@
 package br.com.emendes.yourreviewapi.util.faker;
 
 import br.com.emendes.yourreviewapi.dto.response.ReviewDetailsResponse;
+import br.com.emendes.yourreviewapi.dto.response.ReviewResponse;
 import br.com.emendes.yourreviewapi.dto.response.ReviewSummaryResponse;
 import br.com.emendes.yourreviewapi.model.entity.Review;
 import br.com.emendes.yourreviewapi.repository.projection.ReviewDetailsProjection;
@@ -102,10 +103,10 @@ public class ReviewFaker {
   }
 
   /**
-   * Retorna um objeto {@link ReviewDetailsResponse} com todos os campos.
+   * Retorna um objeto {@link ReviewResponse} com todos os campos.
    */
-  public static ReviewDetailsResponse reviewDetailsResponse() {
-    return ReviewDetailsResponse.builder()
+  public static ReviewResponse reviewResponse() {
+    return ReviewResponse.builder()
         .id(2_000_000L)
         .vote(9)
         .opinion("Lorem ipsum dolor sit amet")
@@ -116,10 +117,10 @@ public class ReviewFaker {
   }
 
   /**
-   * Retorna um objeto {@link ReviewDetailsResponse} sem o campo opinion.
+   * Retorna um objeto {@link ReviewResponse} sem o campo opinion.
    */
-  public static ReviewDetailsResponse reviewDetailsResponseWithoutOpinion() {
-    return ReviewDetailsResponse.builder()
+  public static ReviewResponse reviewResponseWithoutOpinion() {
+    return ReviewResponse.builder()
         .id(2_000_000L)
         .vote(9)
         .userId(100L)
@@ -129,10 +130,10 @@ public class ReviewFaker {
   }
 
   /**
-   * Retorna um objeto {@link ReviewDetailsResponse} com dados atualizados.
+   * Retorna um objeto {@link ReviewResponse} com dados atualizados.
    */
-  public static ReviewDetailsResponse reviewDetailsResponseUpdated() {
-    return ReviewDetailsResponse.builder()
+  public static ReviewResponse reviewResponseUpdated() {
+    return ReviewResponse.builder()
         .id(2_000_000L)
         .vote(8)
         .opinion("Lorem ipsum dolor sit amet updated")
@@ -143,14 +144,28 @@ public class ReviewFaker {
   }
 
   /**
-   * Retorna um objeto {@link ReviewDetailsResponse} com dados atualizados e sem opinion.
+   * Retorna um objeto {@link ReviewResponse} com dados atualizados e sem opinion.
    */
-  public static ReviewDetailsResponse reviewDetailsResponseUpdatedWithoutOpinion() {
-    return ReviewDetailsResponse.builder()
+  public static ReviewResponse reviewResponseUpdatedWithoutOpinion() {
+    return ReviewResponse.builder()
         .id(2_000_000L)
         .vote(8)
         .userId(100L)
         .movieId("1000000")
+        .createdAt(LocalDateTime.parse("2024-02-09T10:00:00"))
+        .build();
+  }
+
+  /**
+   * Retorna um objeto {@link ReviewDetailsResponse} com todos os campos.
+   */
+  public static ReviewDetailsResponse reviewDetailsResponse() {
+    return ReviewDetailsResponse.builder()
+        .id(1_000_000_000L)
+        .vote(9)
+        .opinion("Lorem ipsum dolor sit amet")
+        .userId(100L)
+        .movie(MovieFaker.movieSummaryResponse())
         .createdAt(LocalDateTime.parse("2024-02-09T10:00:00"))
         .build();
   }


### PR DESCRIPTION
A busca de Review por id (GET /api/v1/review/{reviewId} agora retornará também dados resumidos do Movie relacionado com a Review buscada.

ajustar register e update de review para retornar um objeto ReviewResponse
add MovieService#findSummarizedById para buscar informações resumidas de um Movie por id
ajustar os testes automatizados de acordo com as mudanças na busca de review por id