### PR TITLE
feat: add total de votos e nota média de um filme na busca detalhada de filme por id

### DIFF
--- a/src/main/java/br/com/emendes/yourreviewapi/dto/MovieVotesAverage.java
+++ b/src/main/java/br/com/emendes/yourreviewapi/dto/MovieVotesAverage.java
@@ -1,0 +1,22 @@
+package br.com.emendes.yourreviewapi.dto;
+
+import lombok.Builder;
+
+import java.math.BigDecimal;
+
+/**
+ * Record com as informações de pontuação de um Movie.
+ *
+ * @param id            identificador do MovieVotes.
+ * @param movieId       identificador do Movie associado com o MovieVotes.
+ * @param reviewTotal   valor total de reviews.
+ * @param reviewAverage valor médio das reviews.
+ */
+@Builder
+public record MovieVotesAverage(
+    Long id,
+    String movieId,
+    long reviewTotal,
+    BigDecimal reviewAverage
+) {
+}

--- a/src/main/java/br/com/emendes/yourreviewapi/dto/response/MovieDetailsResponse.java
+++ b/src/main/java/br/com/emendes/yourreviewapi/dto/response/MovieDetailsResponse.java
@@ -1,7 +1,9 @@
 package br.com.emendes.yourreviewapi.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 
 /**
@@ -14,6 +16,8 @@ import java.time.LocalDate;
  * @param originalLanguage idioma original do filme.
  * @param posterPath       path da imagem do poster do filme.
  * @param backdropPath     path da imagem de pano de fundo do filme.
+ * @param reviewTotal      total de avaliações que o Movie recebeu no sistema.
+ * @param reviewAverage    valor médio das avaliações que Movie recebeu.
  */
 @Builder
 public record MovieDetailsResponse(
@@ -23,6 +27,10 @@ public record MovieDetailsResponse(
     LocalDate releaseDate,
     String originalLanguage,
     String posterPath,
-    String backdropPath
+    String backdropPath,
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    Long reviewTotal,
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    BigDecimal reviewAverage
 ) {
 }

--- a/src/main/java/br/com/emendes/yourreviewapi/mapper/MovieMapper.java
+++ b/src/main/java/br/com/emendes/yourreviewapi/mapper/MovieMapper.java
@@ -1,5 +1,6 @@
 package br.com.emendes.yourreviewapi.mapper;
 
+import br.com.emendes.yourreviewapi.dto.MovieVotesAverage;
 import br.com.emendes.yourreviewapi.dto.response.MovieDetailsResponse;
 import br.com.emendes.yourreviewapi.dto.response.MovieSummaryResponse;
 import br.com.emendes.yourreviewapi.dto.response.TMDbMovieResponse;
@@ -22,11 +23,12 @@ public interface MovieMapper {
   /**
    * Mapeia um objeto Movie para MovieDetailsResponse.
    *
-   * @param movie objeto a ser mapeado para MovieDetailsResponse.
+   * @param movie             objeto a ser mapeado para MovieDetailsResponse.
+   * @param movieVotesAverage objeto contendo as informações de pontuação do Movie.
    * @return objeto MovieDetailsResponse com os dados de Movie.
    * @throws IllegalArgumentException caso {@code movie} seja null.
    */
-  MovieDetailsResponse toMovieDetailsResponse(Movie movie);
+  MovieDetailsResponse toMovieDetailsResponse(Movie movie, MovieVotesAverage movieVotesAverage);
 
   /**
    * Mapeia um objeto TMDbMovieResponse para Movie.

--- a/src/main/java/br/com/emendes/yourreviewapi/mapper/impl/MovieMapperImpl.java
+++ b/src/main/java/br/com/emendes/yourreviewapi/mapper/impl/MovieMapperImpl.java
@@ -1,5 +1,6 @@
 package br.com.emendes.yourreviewapi.mapper.impl;
 
+import br.com.emendes.yourreviewapi.dto.MovieVotesAverage;
 import br.com.emendes.yourreviewapi.dto.response.MovieDetailsResponse;
 import br.com.emendes.yourreviewapi.dto.response.MovieSummaryResponse;
 import br.com.emendes.yourreviewapi.dto.response.TMDbMovieResponse;
@@ -27,18 +28,25 @@ public class MovieMapperImpl implements MovieMapper {
   }
 
   @Override
-  public MovieDetailsResponse toMovieDetailsResponse(Movie movie) {
+  public MovieDetailsResponse toMovieDetailsResponse(Movie movie, MovieVotesAverage movieVotesAverage) {
     Assert.notNull(movie, "movie must not be null");
 
-    return MovieDetailsResponse.builder()
+    MovieDetailsResponse.MovieDetailsResponseBuilder movieDetailsResponseBuilder = MovieDetailsResponse.builder()
         .id(movie.id())
         .title(movie.title())
         .overview(movie.overview())
         .releaseDate(movie.releaseDate())
         .originalLanguage(movie.originalLanguage())
         .posterPath(movie.posterPath())
-        .backdropPath(movie.backdropPath())
-        .build();
+        .backdropPath(movie.backdropPath());
+
+    if (movieVotesAverage != null) {
+      movieDetailsResponseBuilder
+          .reviewTotal(movieVotesAverage.reviewTotal())
+          .reviewAverage(movieVotesAverage.reviewAverage());
+    }
+
+    return movieDetailsResponseBuilder.build();
   }
 
   @Override

--- a/src/main/java/br/com/emendes/yourreviewapi/service/MovieService.java
+++ b/src/main/java/br/com/emendes/yourreviewapi/service/MovieService.java
@@ -43,11 +43,4 @@ public interface MovieService {
    */
   MovieSummaryResponse findSummarizedById(@NotBlank(message = "{MovieService.findById.movieId.NotBlank.message}") String movieId);
 
-  /**
-   * Verifica se existe Movie para o dado {@code movieId}
-   *
-   * @param movieId identificador do filme a ser verificado.
-   * @return {@code true} caso exista Movie com o dado {@code movieId}, false caso contrário.
-   */
-  boolean existsMovieById(@NotBlank(message = "{MovieService.findById.movieId.NotBlank.message}") String movieId);
 }

--- a/src/main/java/br/com/emendes/yourreviewapi/service/MovieVotesService.java
+++ b/src/main/java/br/com/emendes/yourreviewapi/service/MovieVotesService.java
@@ -1,5 +1,6 @@
 package br.com.emendes.yourreviewapi.service;
 
+import br.com.emendes.yourreviewapi.dto.MovieVotesAverage;
 import br.com.emendes.yourreviewapi.exception.MovieNotFoundException;
 import br.com.emendes.yourreviewapi.model.Movie;
 import br.com.emendes.yourreviewapi.model.entity.MovieVotes;
@@ -28,5 +29,14 @@ public interface MovieVotesService {
    * @throws MovieNotFoundException caso não exista um Movie para o dado {@code movieId}.
    */
   MovieVotes generateNonVotedMovieVotes(String movieId);
+
+  /**
+   * Busca {@link MovieVotesAverage} por movieId.
+   *
+   * @param movieId identificador do Movie ao qual o MovieVotes está associado.
+   * @return {@code Optinal<MovieVotesAverage>} contendo MovieVotesAverage caso seja encontrado,
+   * ou {@link Optional#empty()} caso contrário.
+   */
+  Optional<MovieVotesAverage> findAverageByMovieId(String movieId);
 
 }

--- a/src/main/java/br/com/emendes/yourreviewapi/service/impl/MovieServiceImpl.java
+++ b/src/main/java/br/com/emendes/yourreviewapi/service/impl/MovieServiceImpl.java
@@ -3,9 +3,9 @@ package br.com.emendes.yourreviewapi.service.impl;
 import br.com.emendes.yourreviewapi.client.MovieClient;
 import br.com.emendes.yourreviewapi.dto.response.MovieDetailsResponse;
 import br.com.emendes.yourreviewapi.dto.response.MovieSummaryResponse;
-import br.com.emendes.yourreviewapi.exception.MovieNotFoundException;
 import br.com.emendes.yourreviewapi.mapper.MovieMapper;
 import br.com.emendes.yourreviewapi.service.MovieService;
+import br.com.emendes.yourreviewapi.service.MovieVotesService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -21,6 +21,7 @@ public class MovieServiceImpl implements MovieService {
 
   private final MovieClient movieClient;
   private final MovieMapper movieMapper;
+  private final MovieVotesService movieVotesService;
 
   @Override
   public Page<MovieSummaryResponse> findByName(String name, int page) {
@@ -33,7 +34,9 @@ public class MovieServiceImpl implements MovieService {
   public MovieDetailsResponse findDetailedById(String movieId) {
     log.info("Searching for movie with id: {}", movieId);
 
-    return movieMapper.toMovieDetailsResponse(movieClient.findById(movieId));
+    return movieMapper.toMovieDetailsResponse(
+        movieClient.findById(movieId),
+        movieVotesService.findAverageByMovieId(movieId).orElse(null));
   }
 
   @Override
@@ -41,18 +44,6 @@ public class MovieServiceImpl implements MovieService {
     log.info("Searching for movie with id: {}", movieId);
 
     return movieMapper.toMovieSummaryResponse(movieClient.findById(movieId));
-  }
-
-  @Override
-  public boolean existsMovieById(String movieId) {
-    log.info("checking if there is a movie for id: {}", movieId);
-
-    try {
-      movieClient.findById(movieId);
-      return true;
-    } catch (MovieNotFoundException exception) {
-      return false;
-    }
   }
 
 }

--- a/src/test/java/br/com/emendes/yourreviewapi/unit/mapper/impl/MovieMapperImplTest.java
+++ b/src/test/java/br/com/emendes/yourreviewapi/unit/mapper/impl/MovieMapperImplTest.java
@@ -1,5 +1,6 @@
 package br.com.emendes.yourreviewapi.unit.mapper.impl;
 
+import br.com.emendes.yourreviewapi.dto.MovieVotesAverage;
 import br.com.emendes.yourreviewapi.dto.response.MovieDetailsResponse;
 import br.com.emendes.yourreviewapi.dto.response.MovieSummaryResponse;
 import br.com.emendes.yourreviewapi.dto.response.TMDbMovieResponse;
@@ -8,6 +9,7 @@ import br.com.emendes.yourreviewapi.model.Movie;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -61,7 +63,14 @@ class MovieMapperImplTest {
         .originalLanguage("en")
         .build();
 
-    MovieDetailsResponse actualMovieDetailsResponse = movieMapper.toMovieDetailsResponse(movie);
+    MovieVotesAverage movieVotesAverage = MovieVotesAverage.builder()
+        .id(4_321L)
+        .reviewTotal(40)
+        .reviewAverage(new BigDecimal("3.07"))
+        .movieId("1234")
+        .build();
+
+    MovieDetailsResponse actualMovieDetailsResponse = movieMapper.toMovieDetailsResponse(movie, movieVotesAverage);
 
     assertThat(actualMovieDetailsResponse).isNotNull();
     assertThat(actualMovieDetailsResponse.id()).isNotNull().isEqualTo("1234");
@@ -71,13 +80,49 @@ class MovieMapperImplTest {
     assertThat(actualMovieDetailsResponse.backdropPath()).isNotNull().isEqualTo("/01234");
     assertThat(actualMovieDetailsResponse.originalLanguage()).isNotNull().isEqualTo("en");
     assertThat(actualMovieDetailsResponse.overview()).isNotNull().isEqualTo("Lorem ipsum dolor sit amet");
+    assertThat(actualMovieDetailsResponse.reviewTotal()).isEqualTo(40);
+    assertThat(actualMovieDetailsResponse.reviewAverage()).isNotNull().isEqualTo("3.07");
+  }
+
+  @Test
+  @DisplayName("toMovieDetailsResponse must return MovieDetailsResponse without punctuation when movieVotesResponse is null")
+  void toMovieDetailsResponse_MustReturnMovieDetailsResponseWithoutPunctuation_WhenMovieVotesAverageIsNull() {
+    Movie movie = Movie.builder()
+        .id("1234")
+        .title("XPTO")
+        .posterPath("/1234")
+        .backdropPath("/01234")
+        .overview("Lorem ipsum dolor sit amet")
+        .releaseDate(LocalDate.parse("2024-01-16"))
+        .originalLanguage("en")
+        .build();
+
+    MovieDetailsResponse actualMovieDetailsResponse = movieMapper.toMovieDetailsResponse(movie, null);
+
+    assertThat(actualMovieDetailsResponse).isNotNull();
+    assertThat(actualMovieDetailsResponse.id()).isNotNull().isEqualTo("1234");
+    assertThat(actualMovieDetailsResponse.title()).isNotNull().isEqualTo("XPTO");
+    assertThat(actualMovieDetailsResponse.releaseDate()).isNotNull().isEqualTo("2024-01-16");
+    assertThat(actualMovieDetailsResponse.posterPath()).isNotNull().isEqualTo("/1234");
+    assertThat(actualMovieDetailsResponse.backdropPath()).isNotNull().isEqualTo("/01234");
+    assertThat(actualMovieDetailsResponse.originalLanguage()).isNotNull().isEqualTo("en");
+    assertThat(actualMovieDetailsResponse.overview()).isNotNull().isEqualTo("Lorem ipsum dolor sit amet");
+    assertThat(actualMovieDetailsResponse.reviewTotal()).isNull();
+    assertThat(actualMovieDetailsResponse.reviewAverage()).isNull();
   }
 
   @Test
   @DisplayName("toMovieDetailsResponse must throw IllegalArgumentException when movie parameter is null")
   void toMovieDetailsResponse_MustThrowIllegalArgumentException_WhenMovieParameterIsNull() {
+    MovieVotesAverage movieVotesAverage = MovieVotesAverage.builder()
+        .id(4_321L)
+        .reviewTotal(123)
+        .reviewAverage(new BigDecimal("3.07"))
+        .movieId("1234")
+        .build();
+
     assertThatExceptionOfType(IllegalArgumentException.class)
-        .isThrownBy(() -> movieMapper.toMovieDetailsResponse(null))
+        .isThrownBy(() -> movieMapper.toMovieDetailsResponse(null, movieVotesAverage))
         .withMessage("movie must not be null");
   }
 

--- a/src/test/java/br/com/emendes/yourreviewapi/util/faker/MovieFaker.java
+++ b/src/test/java/br/com/emendes/yourreviewapi/util/faker/MovieFaker.java
@@ -72,6 +72,8 @@ public class MovieFaker {
         .backdropPath(MOVIE_BACKDROP_PATH)
         .releaseDate(MOVIE_RELEASE_DATE)
         .originalLanguage(MOVIE_ORIGINAL_LANGUAGE)
+        .reviewTotal(MovieVotesFaker.MOVIE_VOTES_REVIEW_TOTAL)
+        .reviewAverage(MovieVotesFaker.REVIEW_AVERAGE)
         .build();
   }
 
@@ -82,4 +84,20 @@ public class MovieFaker {
     return new PageImpl<>(List.of(), PageRequest.of(0, 20), 0);
   }
 
+  /**
+   * Retorna MovieDetailsResponse com os mesmos dados de movie()
+   * mas sem {@link MovieDetailsResponse#reviewTotal() reviewTotal} e
+   * {@link MovieDetailsResponse#reviewAverage() reviewAverage}.
+   */
+  public static MovieDetailsResponse movieDetailsResponseWithoutPunctuation() {
+    return MovieDetailsResponse.builder()
+        .id(MOVIE_ID)
+        .title(MOVIE_TITLE)
+        .overview(MOVIE_OVERVIEW)
+        .posterPath(MOVIE_POSTER_PATH)
+        .backdropPath(MOVIE_BACKDROP_PATH)
+        .releaseDate(MOVIE_RELEASE_DATE)
+        .originalLanguage(MOVIE_ORIGINAL_LANGUAGE)
+        .build();
+  }
 }

--- a/src/test/java/br/com/emendes/yourreviewapi/util/faker/MovieVotesFaker.java
+++ b/src/test/java/br/com/emendes/yourreviewapi/util/faker/MovieVotesFaker.java
@@ -1,7 +1,9 @@
 package br.com.emendes.yourreviewapi.util.faker;
 
+import br.com.emendes.yourreviewapi.dto.MovieVotesAverage;
 import br.com.emendes.yourreviewapi.model.entity.MovieVotes;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
@@ -12,6 +14,8 @@ public class MovieVotesFaker {
 
   public static final long MOVIE_VOTES_ID = 4_321L;
   public static final LocalDateTime MOVIE_VOTES_CREATED_AT = LocalDateTime.parse("2024-02-09T12:00:00");
+  public static final long MOVIE_VOTES_REVIEW_TOTAL = 40;
+  public static final BigDecimal REVIEW_AVERAGE = new BigDecimal("3.07");
 
   private MovieVotesFaker() {
   }
@@ -22,7 +26,7 @@ public class MovieVotesFaker {
   public static MovieVotes movieVotes() {
     return MovieVotes.builder()
         .id(MOVIE_VOTES_ID)
-        .voteCount(40)
+        .voteCount(MOVIE_VOTES_REVIEW_TOTAL)
         .voteTotal(123)
         .movieId(MovieFaker.MOVIE_ID)
         .createdAt(MOVIE_VOTES_CREATED_AT)
@@ -47,4 +51,24 @@ public class MovieVotesFaker {
         .createdAt(MOVIE_VOTES_CREATED_AT)
         .build();
   }
+
+  /**
+   * Retorna um objeto MovieVotesAverage com todos os campos.
+   */
+  public static MovieVotesAverage movieVotesAverage() {
+    return MovieVotesAverage.builder()
+        .id(MOVIE_VOTES_ID)
+        .reviewTotal(MOVIE_VOTES_REVIEW_TOTAL)
+        .reviewAverage(REVIEW_AVERAGE)
+        .movieId("1234")
+        .build();
+  }
+
+  /**
+   * Retorna Optional<MovieVotesAverage> com todos os campos.
+   */
+  public static Optional<MovieVotesAverage> movieVotesAverageOptional() {
+    return Optional.of(movieVotesAverage());
+  }
+
 }


### PR DESCRIPTION
update MovieDetailsResponse para conter reviewTotal e reviewAverage.

update MovieMapper#toMovieDetailsResponse para mapear as novas informações do Movie

add MovieVotesService#findAverageByMovieId para buscar o total de votos e total de notas de um filme e calcular a valor médio dos votos.

update MovieVotesService#generateNonVotedMovieVotes para **não interagir** com MovieService para não acontecer dependencia cíclica (obs: não gostei do fato de MovieVotesService interagir com MovieClient diretamente em vez de MovieService, mas foi o que deu pra fazer por hora.)

update testes automatizados para testar as novas mudanças.