### PR TITLE
fix: ajustar o método MovieVotesServiceImpl#findAverageByMovieId para não ocorrer divisão por zero

### DIFF
--- a/src/main/java/br/com/emendes/yourreviewapi/service/impl/MovieVotesServiceImpl.java
+++ b/src/main/java/br/com/emendes/yourreviewapi/service/impl/MovieVotesServiceImpl.java
@@ -56,18 +56,28 @@ public class MovieVotesServiceImpl implements MovieVotesService {
 
   @Override
   public Optional<MovieVotesAverage> findAverageByMovieId(String movieId) {
-    return findByMovieId(movieId).map(movieVotes -> {
-      BigDecimal total = BigDecimal.valueOf(movieVotes.getVoteTotal());
-      BigDecimal count = BigDecimal.valueOf(movieVotes.getVoteCount());
-      BigDecimal reviewAverage = total.divide(count, 2, RoundingMode.HALF_DOWN);
+    return findByMovieId(movieId)
+        .filter(movieVotes -> movieVotes.getVoteCount() != 0)
+        .map(this::toMovieVotesAverage);
+  }
 
-      return MovieVotesAverage.builder()
-          .id(movieVotes.getId())
-          .reviewTotal(movieVotes.getVoteCount())
-          .reviewAverage(reviewAverage)
-          .movieId(movieVotes.getMovieId())
-          .build();
-    });
+  /**
+   * Mapeia um objeto {@link MovieVotes} para {@link MovieVotesAverage}.
+   *
+   * @param movieVotes objeto MovieVotes a ser mapeado.
+   * @return {@link MovieVotesAverage} com os dados de {@code movieVotes}.
+   */
+  private MovieVotesAverage toMovieVotesAverage(MovieVotes movieVotes) {
+    BigDecimal total = BigDecimal.valueOf(movieVotes.getVoteTotal());
+    BigDecimal count = BigDecimal.valueOf(movieVotes.getVoteCount());
+    BigDecimal reviewAverage = total.divide(count, 2, RoundingMode.HALF_DOWN);
+
+    return MovieVotesAverage.builder()
+        .id(movieVotes.getId())
+        .reviewTotal(movieVotes.getVoteCount())
+        .reviewAverage(reviewAverage)
+        .movieId(movieVotes.getMovieId())
+        .build();
   }
 
   /**

--- a/src/test/java/br/com/emendes/yourreviewapi/unit/service/impl/MovieVotesServiceImplTest.java
+++ b/src/test/java/br/com/emendes/yourreviewapi/unit/service/impl/MovieVotesServiceImplTest.java
@@ -146,6 +146,17 @@ class MovieVotesServiceImplTest {
       assertThat(actualMovieVotesOptional).isNotNull().isNotPresent();
     }
 
+    @Test
+    @DisplayName("findAverageByMovieId must return empty Optional when MovieVotes founded has zero voteCount")
+    void findAverageByMovieId_MustReturnEmptyOptional_WhenMovieVotesFoundedHasZeroVoteCount() {
+      when(movieVotesRepositoryMock.findByMovieId("1234"))
+          .thenReturn(MovieVotesFaker.movieVotesWithZeroVotesOptional());
+
+      Optional<MovieVotesAverage> actualMovieVotesOptional = movieVotesService.findAverageByMovieId("1234");
+
+      assertThat(actualMovieVotesOptional).isNotNull().isNotPresent();
+    }
+
     @ParameterizedTest
     @NullAndEmptySource
     @ValueSource(strings = {"   ", "\t", "\n"})

--- a/src/test/java/br/com/emendes/yourreviewapi/util/faker/MovieVotesFaker.java
+++ b/src/test/java/br/com/emendes/yourreviewapi/util/faker/MovieVotesFaker.java
@@ -34,10 +34,30 @@ public class MovieVotesFaker {
   }
 
   /**
+   * Retorna {@link MovieVotes} com voteCount e voteTotal iguais a zero.
+   */
+  public static MovieVotes movieVotesWithZeroVotes() {
+    return MovieVotes.builder()
+        .id(MOVIE_VOTES_ID)
+        .voteCount(0)
+        .voteTotal(0)
+        .movieId(MovieFaker.MOVIE_ID)
+        .createdAt(MOVIE_VOTES_CREATED_AT)
+        .build();
+  }
+
+  /**
    * Retorna {@code Optional<MovieVotes>} com todos os campos.
    */
   public static Optional<MovieVotes> movieVotesOptional() {
     return Optional.of(movieVotes());
+  }
+
+  /**
+   * Retorna {@code Optional<MovieVotes>} com voteCount e voteTotal iguais a zero.
+   */
+  public static Optional<MovieVotes> movieVotesWithZeroVotesOptional() {
+    return Optional.of(movieVotesWithZeroVotes());
   }
 
   /**


### PR DESCRIPTION
 - fix método MovieVotesServiceImpl#findAverageByMovieId para não ocorrer divisão por zero, *filter* é aplicado ao *Optional* retornado pelo banco de dados, com a verificação se *voteCount* é diferente de zero.
    ```java
      .filter(movieVotes -> movieVotes.getVoteCount() != 0)
    ```
- add testes de unidade para verificar se a alteração esta correta.
